### PR TITLE
Lokapi pwd requested

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@vue/eslint-config-typescript": "^7.0.0",
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^7.0.0",
-    "node-sass": "^4.12.0",
+    "sass": "^1.44.0",
     "sass-loader": "^8.0.2",
     "typescript": "~4.1.5"
   }

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -5,6 +5,8 @@
 @import "custom-variables";
 // Bulma Import */
 @import "~bulma/bulma";
+// Sweetalert2 override variables
+@import "swal-custom";
 // Roboto
 @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap");
 

--- a/src/assets/swal-custom.scss
+++ b/src/assets/swal-custom.scss
@@ -1,0 +1,34 @@
+@import '~sweetalert2/src/variables';
+// Monujo variables
+$button-border-radius: 47px;
+$input-border-radius: 4px;
+
+// Sweetalert2 customizations
+
+// Buttons
+$swal2-confirm-button-background-color: #009688;
+$swal2-deny-button-background-color: #960f29;
+$swal2-confirm-button-border-radius: $button-border-radius;
+$swal2-deny-button-border-radius: $button-border-radius;
+$swal2-cancel-button-border-radius: $button-border-radius;
+// Inputs
+$swal2-input-border-radius: $input-border-radius;
+$swal2-input-box-shadow: rgba(10, 10, 10, 0.05) 0px 0.0625em 0.125em inset;
+// Inputs:focus
+$swal2-input-focus-border: 1px solid #485fc7;
+$swal2-input-focus-outline: none;
+$swal2-input-focus-box-shadow: 0 0 0 0.125em rgba(72, 95, 199, 0.25);
+
+@import '~sweetalert2/src/sweetalert2';
+
+.swal2-input:hover,
+.swal2-file:hover,
+.swal2-textarea:hover {
+  border-color: #b5b5b5;
+
+  &:focus {
+    border: $swal2-input-focus-border;
+    outline: $swal2-input-focus-outline;
+    box-shadow: $swal2-input-focus-box-shadow;
+  }
+}

--- a/src/services/lokapiService.ts
+++ b/src/services/lokapiService.ts
@@ -12,31 +12,57 @@ class LokAPI extends LokAPIBrowserAbstract {
     cyclos
   }
 
-  requestLocalPassword = async function (state: string) {
-    let text = ''
-    if (state === 'failedUnlock') {
-      text = 'Échec du déchiffrage. ' +
-        'Le mot de passe était probablement incorrect. '+
-        'Ré-essayez une nouvelle fois'  // XXXvlab: need i18n
-    }
-    const ret = await Swal.fire({
-      title: 'Entrez votre mot de passe',  // XXXvlab: need i18n
-      text,
-      showCloseButton: true,
-      input: 'password',
-      inputLabel: 'Mot de passe du portefeuille',  // XXXvlab: need i18n
-      inputPlaceholder: 'Votre mot de passe',  // XXXvlab: need i18n
-      inputAttributes: {
-        maxlength: '32',
-        autocapitalize: 'off',
-        autocorrect: 'off'
+
+  requestLocalPassword = (state => {
+    let rememberedPassword = { pwd: '', inputTime: 0 }
+    return async (state:any) => {
+      let text = ''
+
+      // Lets see if we have a (still valid) password in there...
+      // ... that was used less than 30secs ago
+      // If it's the case, we will provide it to the lokapi right away
+      if (rememberedPassword.pwd.length > 0
+        && rememberedPassword.inputTime + 30000 > Date.now()
+        && state === 'firstTry'
+      ) {
+        // Valid pwd -> update the last used time and provide
+        // the pwd to the lokapi
+        rememberedPassword.inputTime = Date.now()
+        return rememberedPassword.pwd
+
+      // No valid pwd
+      // so we make sure the pwd is reset
+      // and ask for it again
+      } else {
+        rememberedPassword = { pwd: '', inputTime: 0 }
       }
-    })
-    if (ret.isConfirmed) {
-      return ret.value
+
+      if (state === 'failedUnlock') {
+        rememberedPassword = { pwd: '', inputTime: 0 }
+        text = 'Échec du déchiffrage. ' +
+          'Le mot de passe était probablement incorrect. '+
+          'Ré-essayez une nouvelle fois'  // XXXvlab: need i16n
+      }
+      const ret = await Swal.fire({
+        title: 'Entrez votre mot de passe',  // XXXvlab: need i16n
+        text,
+        showCloseButton: true,
+        input: 'password',
+        inputLabel: 'Mot de passe du portefeuille',  // XXXvlab: need i16n
+        inputPlaceholder: 'Votre mot de passe',  // XXXvlab: need i16n
+        inputAttributes: {
+          maxlength: '32',
+          autocapitalize: 'off',
+          autocorrect: 'off'
+        }
+      })
+      if (ret.isConfirmed) {
+        rememberedPassword = { pwd: ret.value, inputTime: Date.now() }
+        return ret.value
+      }
+      throw new Error('User canceled the dialog box')
     }
-    throw new Error('User canceled the dialog box')
-  }
+  })()
 
   requestLogin() {
     console.log("Login requested !")


### PR DESCRIPTION
This PR will adapt the sweetalert component used to prompt for the user password (for money transfer) and the admin password (for the future money account validation procedure) in terms of UI design.

It will also enable the remembering of the provided password for a time of 30 seconds, so that the admin can sequentially validate accounts without needing to re-enter the pwd each time.