### PR TITLE
Fix logout action

### DIFF
--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -61,9 +61,9 @@
 
             <hr class="navbar-divider">
 
-            <router-link to="/" @click="logout" class="navbar-item">
+            <a @click="logout" class="navbar-item">
               Déconnexion
-            </router-link>
+            </a>
           </div>
         </div>
 
@@ -85,6 +85,7 @@ import { Options, Vue } from 'vue-class-component';
   methods : {
     logout() {
       this.$store.dispatch("askLogOut")
+      this.$router.push({ name: 'Login' })
     }
   },
   computed: {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHashHistory, RouteRecordRaw } from "vue-router";
+import store from '../store'
 import Dashboard from "../views/Dashboard.vue";
 import Login from "../views/Login.vue";
 import CreateMyAccount from "../views/CreateMyAccount.vue";
@@ -35,5 +36,11 @@ const router = createRouter({
   history: createWebHashHistory(),
   routes,
 });
+
+// Authentication guard
+router.beforeEach((to, from, next) => {
+  if (to.name !== 'Login' && store.getters.isAuthenticated === false) next({ name: 'Login' })
+  else next()
+})
 
 export default router;

--- a/src/store/lokapi.ts
+++ b/src/store/lokapi.ts
@@ -17,7 +17,7 @@ export var moduleLokAPI = {
     accounts:[],
     accountsLoaded: false,
     recipient:"",
-    isLog:false,
+    isLog:null,
     paymentUrl: "",
     recipientHistory:[],
     isMultiCurrency: false,  // Are we displaying accounts with different currencies ?
@@ -58,7 +58,8 @@ export var moduleLokAPI = {
     async genPaymentLink({commit}:any,amount:number) {
       await commit("genPaymentLink", amount)
     },
-    askLogOut({commit}:any) {
+    async askLogOut({commit}:any) {
+      await lokApiService.logout()
       commit("logout")
     },
     async checkPasswordStrength({ commit, state }:any, [password, accountBackend]: Array<string>) {
@@ -116,7 +117,6 @@ export var moduleLokAPI = {
     logout(state: any) {
       state.status = ''
       state.apiToken = ''
-      state.status= ''
       state.userProfile= null
       state.transactions=null
       state.thisWeektransactions=null
@@ -129,6 +129,7 @@ export var moduleLokAPI = {
       state.isMultiCurrency = false
       state.hasUserAccountValidationRights = false
       state.pendingUserAccounts = []
+      state.backends = {}
     },
 
     async setBalCurr(state:any) {
@@ -232,6 +233,9 @@ export var moduleLokAPI = {
       return function(): any {
         return 'https://' + lokApiService.host
       }
+    },
+    isAuthenticated: (state: any) => {
+      return state.isLog
     },
   }
 }


### PR DESCRIPTION
This PR will fix the logout button which did not really do anything except going to the / route (login route).
Now the store values are reset properly, the user is really disconnected from the lokapi (tokens) and route guard mechanisms are in place to automatically redirect to the login page the UnauthUser which is trying to access any route, even non-existent ones.

PR based on #66, must validate #66 before this one.

Closes #48