### PR TITLE
fix: payment modal which could be scrolled even when not necessary

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -351,11 +351,6 @@ body {
   color: white;
 }
 
-.modal-body {
-  height: 100% !important;
-  width: 100% !important;
-}
-
 .modal-body-frame-send-money {
   margin: 20px 0;
   height: 70%;


### PR DESCRIPTION
This PR will remove the forced height of the payment modals bodies which could lead to unwanted/unneeded scrolling.

Closes #56 