### PR TITLE
fix: catch error thrown by backend

### DIFF
--- a/src/views/admin/PendingAccounts.vue
+++ b/src/views/admin/PendingAccounts.vue
@@ -51,26 +51,28 @@
       }
     },
     methods: {
-      validateUserAccount(account: any):void {
-        account.validateCreation()
-          .catch((err: any) => {
-            this.$Swal.fire({
-              position: 'top',
-              icon: 'error',
-              title: 'Il y a eu un problème lors de la tentative de validation de l\'utilisateur ' + account.name,
-              showConfirmButton: false,
-              timer: 3000
-            })
-          }).then((result: any) => {
-            this.$store.dispatch('fetchPendingUserAccounts')
-            this.$Swal.fire({
-              position: 'top',
-              icon: 'success',
-              title: 'Le compte de l\'utilisateur ' + account.name + ' a été validé',
-              showConfirmButton: false,
-              timer: 3000
-            })
+      async validateUserAccount(account: any): Promise<void> {
+        try {
+          await account.validateCreation()
+        } catch (err) {
+          this.$Swal.fire({
+            position: 'top',
+            icon: 'error',
+            title: 'Il y a eu un problème lors de la tentative de validation de l\'utilisateur ' + account.name,
+            showConfirmButton: false,
+            timer: 3000
           })
+          throw err
+        }
+
+        this.$store.dispatch('fetchPendingUserAccounts')
+        this.$Swal.fire({
+          position: 'top',
+          icon: 'success',
+          title: 'Le compte de l\'utilisateur ' + account.name + ' a été validé',
+          showConfirmButton: false,
+          timer: 3000
+        })
       }
     },
   })


### PR DESCRIPTION
Backend errors were ignored and swallowed with no message in console.
And the Failed popup was instantly replaced by the success popup.

I took the liberty to change to try/catch and async syntax that I feel more clear, and probably actually explain how this bug was first introduced as the `.catch()` should have been put after the `.then()` to work properly. This is much clearer in the normal syntax as you don't need to recall these specific behaviors of `.then()/.catch()` and their specific interaction.

Signed-off-by: Valentin Lab <valentin.lab@kalysto.org>