### PR TITLE
fix: dev: fix regression bug where account balances and transactions

### DIFF
--- a/src/components/sendAskMoney/SendAskMoney.vue
+++ b/src/components/sendAskMoney/SendAskMoney.vue
@@ -1269,7 +1269,6 @@
           console.log('Payment failed:', err.message)
           throw err
         }
-        await this.$store.commit("setBalCurr")
         this.$toast.success(
           `Paiement effectué à ${this.recipientName}`,
           {
@@ -1289,7 +1288,8 @@
             }
           })
         }
-        await this.$store.dispatch("fetchTransactions")
+        await this.$store.dispatch("fetchAccounts")
+        await this.$store.dispatch("resetTransactions")
         this.searchName = ""
         this.partners = []
         this.amount = 0


### PR DESCRIPTION
…list would not refresh after transfering money

This bug was introduced with the infinite scroll for the transactions (for the transactions list part).
The part for the account balances may not have been working for more time than that.

(fixes #110)