### PR TITLE
fix: fix button overflowing the modal boxes in credit workflow

### DIFF
--- a/src/components/sendAskMoney/SendAskMoney.vue
+++ b/src/components/sendAskMoney/SendAskMoney.vue
@@ -1348,4 +1348,8 @@ div.account-selector
     box-shadow: none
     border: 2px #eee solid
 
+.button.action
+  white-space: normal
+  height: auto
+
 </style>


### PR DESCRIPTION
This will make the buttons inside the modals wrap lines when they are wider than their containers.