### PR TITLE
fix: fix disabled auth guard due to wrong initial store variable state

### DIFF
--- a/src/store/lokapi.ts
+++ b/src/store/lokapi.ts
@@ -19,7 +19,7 @@ export function lokapiStoreFactory(lokApiService: any) {
       moneyAccounts:[],
       accountsLoaded: false,
       recipient:"",
-      isLog:null,
+      isLog: false,
       paymentUrl: "",
       recipientHistory:[],
       isMultiCurrency: false,  // Are we displaying accounts with different currencies ?


### PR DESCRIPTION
This auth guard prevents a user to navigate to a route that is not allowed (currently allowed routes are "/carto" and "/ (login)") if he is not authenticated by redirecting her to the "/carto" route.