### PR TITLE
Fix reload everywhere

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,22 @@
   import Nav from "@/components/Nav.vue";
 
   @Options({
-    components: { Nav }
+    components: { Nav },
+    async mounted() {
+      if (!this.userProfile) {
+        try {
+          console.log("Trying to Autolog")
+          await this.$store.dispatch("initAutoLogin")
+        } catch(e) {
+          console.error("Error while trying to autolog", e)
+        }
+      }
+    },
+    computed: {
+      userProfile(): string {
+        return this.$store.state.lokapi.userProfile
+      }
+    },
   })
   export default class Login extends Vue {}
 </script>

--- a/src/components/Core.vue
+++ b/src/components/Core.vue
@@ -24,28 +24,6 @@
 
   @Options({
     name:"core",
-    async mounted() {
-      // If this component is loaded, we already are logged in, so
-      // the store already contains the logged in user informations...
-      // Maybe all the following is not useful ?
-      if(!this.userProfile) {
-        try {
-          await this.$store.dispatch("initAutoLogin")
-        } catch(e) {
-          console.error("Error while trying to autolog", e)
-          router.push("/")
-          throw e
-        }
-      }
-    },
-    computed: {
-      // We do not have to rely on an extra db call to get the
-      // information, just use a computed property on the store state (or getter if needed)
-      // and the vuejs magic happens !
-      userProfile(): string {
-        return this.$store.state.lokapi.userProfile
-      }
-    },
     props: {
       msg: String,
     },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -46,6 +46,10 @@ const routes: Array<RouteRecordRaw> = [
     meta: { title: "Validation des demandes de crédit" },
     component: PendingCredits,
   },
+  {
+    path: '/:pathMatch(.*)*',
+    component: Carto
+  },
 ];
 
 const router = createRouter({

--- a/src/services/lokapiService.ts
+++ b/src/services/lokapiService.ts
@@ -65,8 +65,11 @@ export class LokAPI extends LokAPIBrowserAbstract {
   }
 
   requestLogin() {
-    console.log("Login requested !")
-    router.push('/')
+    let lastUrlSegment = window.location.href.split('/').pop()
+    if (lastUrlSegment !== 'carto' && lastUrlSegment !== '') {
+      console.log("Login requested !")
+      router.push('/')
+    }
   }
 
   /**

--- a/src/store/lokapi.ts
+++ b/src/store/lokapi.ts
@@ -52,9 +52,9 @@ export function lokapiStoreFactory(lokApiService: any) {
         dispatch('fetchCreditRequestValidationRights')
       },
       async initAutoLogin({commit, dispatch}:any) {
+        commit('setUserProfile', await lokApiService.getMyContact())
         dispatch("fetchAccounts");
         dispatch('fetchTransactionsBatch')
-        commit('setUserProfile', await lokApiService.getMyContact())
         commit('auth_success')
         await dispatch('setBackends')
         dispatch('fetchUserAccountValidationRights')


### PR DESCRIPTION
This PR will enable refreshing the app and autologin on every page, including "carto".

On all pages except carto and / (login), the app will redirect to login if not authed and will stay on the current page if authed.

(Closes #82)