### PR TITLE
fix: dev: fix typo in gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ package.json
 package-lock.json
 yarn.lock
 /public/config.json
-/public.config.theme.scss
+/public/config.theme.scss
 
 # local env files
 .env.local


### PR DESCRIPTION
This is a simple typo fix. It will ignore the config.theme.scss file placed in the public directory of monujo. This file's purpose is to customize the css variables values.