### PR TITLE
Errors handling and user feedback (based on #154)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
 </template>
 
 <script lang="ts">
+  import { RestExc } from '@lokavaluto/lokapi-browser'
   import { Options, Vue } from 'vue-class-component';
   import Nav from "@/components/Nav.vue";
 
@@ -15,7 +16,17 @@
           console.log("Trying to Autolog")
           await this.$store.dispatch("initAutoLogin")
         } catch(e) {
-          console.error("Error while trying to autolog", e)
+          if (e instanceof RestExc.TokenRequired) {
+            // TokenRequired is cast by lokapi as one of 2 mecanism to
+            // react upon failure of auto-login. As we are already using
+            // the ``requestLogin`` callback, and that this callback issues
+            // a ``router.push("/")`` that won't do anything when already
+            // on this URL, this code will be run and this exception will
+            // be thrown and catched here. Notice that if the login page
+            // was on the URL "/login", that would not be necessary.
+            return
+          }
+          console.log("Error while trying to autolog", e)
         }
       }
     },

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -287,6 +287,7 @@ span.custom-card-destinataire {
 
 .action-footer-container {
   position: fixed !important;
+  z-index: 2;
   bottom: 0 !important;
   width: 100%;
 

--- a/src/components/core/RightCol.vue
+++ b/src/components/core/RightCol.vue
@@ -32,7 +32,7 @@
         </div>
       </div>
 
-      <div v-if="!isLoadingTransactionsBatch && getTrs?.length" class="has-text-centered mt-5">
+      <div v-if="!isLoadingTransactions && getTrs?.length" class="has-text-centered mt-5">
         <button
           @click="showModal = true"
           class="button custom-button custom-inverted"
@@ -65,8 +65,8 @@
       getTrs(): any {
         return this.$store.state.lokapi.thisWeektransactions
       },
-      isLoadingTransactionsBatch(): boolean {
-        return this.$store.state.lokapi.transactionsBatchLoading
+      isLoadingTransactions(): boolean {
+        return this.$store.state.lokapi.transactionsLoading
       }
     },
     watch: {

--- a/src/components/leftCol/YourAccs.vue
+++ b/src/components/leftCol/YourAccs.vue
@@ -3,33 +3,35 @@
   <div
     class="accounts card custom-card custom-card-padding"
   >
-    <a
-      @click="refreshBalanceAndTransactions"
-      title="Rafraîchir le solde et les transactions"
-      class="button is-default is-pulled-right is-rounded refresh"
-    >
-      <span>Rafraîchir</span>
-      <span class="icon is-small">
-        <i class="fas fa-sync"></i>
-      </span>
-    </a>
-    <h2 class="custom-card-title">vos comptes</h2>
     <loading v-model:active="isLoadingAccounts"
              :can-cancel="false"
              :is-full-page="false"/>
     
-    <div class="active">
-      <p class="notification is-default" v-if="!isLoadingAccounts && totalAccountsLoaded === 0">Vous n'avez pas encore de compte</p>
-      <Acc v-for="account in activeVirtualAccounts"
-           :bal="account.bal"
-           :curr="account.curr"
-           :backend="account.backend"
-           :type="account.type"
-           :active="account.active"
-           :subAccounts="account.subAccounts || []"
+    <div class="active" v-if="!isLoadingAccounts">
+      <a
+        @click="refreshBalanceAndTransactions"
+        title="Rafraîchir le solde et les transactions"
+        class="button is-default is-pulled-right is-rounded refresh"
       >
-        <template v-slot:name>{{ account.name }}</template>
-      </Acc>
+        <span>Rafraîchir</span>
+        <span class="icon is-small">
+          <i class="fas fa-sync"></i>
+        </span>
+      </a>
+      <p class="notification is-default" v-if="totalAccountsLoaded === 0">Vous n'avez pas encore de compte</p>
+      <div v-else>
+        <h2 class="custom-card-title">vos comptes</h2>
+        <Acc v-for="account in activeVirtualAccounts"
+             :bal="account.bal"
+             :curr="account.curr"
+             :backend="account.backend"
+             :type="account.type"
+             :active="account.active"
+             :subAccounts="account.subAccounts || []"
+        >
+          <template v-slot:name>{{ account.name }}</template>
+        </Acc>
+      </div>
     </div>
     <div class="inactive" v-if="inactiveVirtualAccounts.length > 0">
       <h2 class="custom-card-title">vos comptes en attente de création</h2>

--- a/src/components/leftCol/YourAccs.vue
+++ b/src/components/leftCol/YourAccs.vue
@@ -18,7 +18,11 @@
           <i class="fas fa-sync"></i>
         </span>
       </a>
-      <p class="notification is-default" v-if="totalAccountsLoaded === 0">Vous n'avez pas encore de compte</p>
+      <div class="notification is-danger is-light" v-if="hasAccountsLoadingError">
+        <p class="mb-4">Une erreur inattendue est survenue pendant le chargement des portefeuilles. Veuillez nous excuser pour le désagrément.</p>
+        <p>Vous pouvez essayer de recharger la page, ou contacter votre administrateur si l'erreur persiste.</p>
+      </div>
+      <p class="notification is-default" v-else-if="totalAccountsLoaded === 0">Vous n'avez pas encore de compte</p>
       <div v-else>
         <h2 class="custom-card-title">vos comptes</h2>
         <Acc v-for="account in activeVirtualAccounts"
@@ -73,6 +77,9 @@
       isLoadingAccounts(): boolean {
         return this.$store.state.lokapi.accountsLoading
       },
+      hasAccountsLoadingError(): boolean {
+        return this.$store.state.lokapi.accountsLoadingError
+      },
       ...mapGetters([
         'activeVirtualAccounts',
         'inactiveVirtualAccounts',
@@ -90,5 +97,6 @@
 <style lang="scss" scoped>
 .refresh {
   margin-top: -9px;
+  z-index: 1;
 }
 </style>

--- a/src/components/rightCol/ThisWeek.vue
+++ b/src/components/rightCol/ThisWeek.vue
@@ -3,7 +3,11 @@
             :can-cancel="false"
             :is-full-page="false"/>
   <div v-if="!isLoadingTransactions">
-    <p v-if="getTrs?.length === 0" class="notification is-default"> Aucune opération dans votre historique</p>
+    <div class="notification is-danger is-light" v-if="hasTransactionsLoadingError">
+      <p class="mb-4">Une erreur inattendue est survenue pendant le chargement des dernières opérations de votre compte. Veuillez nous excuser pour le désagrément.</p>
+      <p>Vous pouvez essayer de recharger la page, ou contacter votre administrateur si l'erreur persiste.</p>
+    </div>
+    <p v-else-if="getTrs?.length === 0" class="notification is-default"> Aucune opération dans votre historique</p>
     <div v-else >
       <h2 class="custom-card-title">Opérations</h2>
       <TransactionSubCard v-for="transaction in getTrs"
@@ -39,7 +43,10 @@
       },
       isLoadingTransactions(): boolean {
         return this.$store.state.lokapi.transactionsLoading
-      }
+      },
+      hasTransactionsLoadingError(): boolean {
+        return this.$store.state.lokapi.transactionsLoadingError
+      },
     },
    
     methods : { 

--- a/src/components/rightCol/ThisWeek.vue
+++ b/src/components/rightCol/ThisWeek.vue
@@ -1,11 +1,11 @@
 <template>
-  <h2 class="custom-card-title">Opérations</h2>
   <loading  v-model:active="isLoadingTransactions"
             :can-cancel="false"
             :is-full-page="false"/>
   <div v-if="!isLoadingTransactions">
     <p v-if="getTrs?.length === 0" class="notification is-default"> Aucune opération dans votre historique</p>
     <div v-else >
+      <h2 class="custom-card-title">Opérations</h2>
       <TransactionSubCard v-for="transaction in getTrs"
                           :key="transaction" :amount="transaction.amount"
                           :symbol="transaction.currency"

--- a/src/components/sendAskMoney/SendAskMoney.vue
+++ b/src/components/sendAskMoney/SendAskMoney.vue
@@ -99,6 +99,9 @@
                       :width= "50"
                       :height= "50"/>
           </div>
+          <div v-else-if="searchRecipientError" class="notification is-light is-danger">
+            Une erreur inattendue est survenue lors de la recherche de destinataires. Veuillez nous excuser pour la gêne occasionnée.
+          </div>
           <div v-else>
             <div v-if="ownCurrenciesPartners.length !== 0" class="custom-card is-flex-direction-column is-align-items-center is-justify-content-space-between">
               <div v-if="ownCurrenciesPartners">
@@ -439,7 +442,8 @@
         urlForHyperlink:"",
         selectedCreditAccount:null,
         showCreditRefreshNotification: false,
-        isLoading: false
+        isLoading: false,
+        searchRecipientError: false,
       }
     },
 
@@ -557,11 +561,13 @@
 
       async searchRecipients() :Promise<void> {
         this.partners = []
+        this.searchRecipientError = false
         var recipients
         try {
           this.isLoading = true
           recipients = await this.$lokapi.searchRecipients(this.searchName)
         } catch (err) {
+          this.searchRecipientError = true
           console.log('searchRecipients() Failed', err)
         }
         this.isLoading = false

--- a/src/views/admin/PendingAccounts.vue
+++ b/src/views/admin/PendingAccounts.vue
@@ -4,14 +4,17 @@
       <div class="columns is-tablet">
         <div class="column">
           <div class="accounts card custom-card custom-card-padding">
-         
             <loading v-model:active="isLoading"
                  :can-cancel="false"
                  :is-full-page= "false"/>
             <div v-if="!isLoading">
+              <div class="notification is-danger is-light" v-if="hasLoadingError">
+                <p class="mb-4">Une erreur inattendue est survenue pendant le chargement de la liste des comptes. Veuillez nous excuser pour le désagrément.</p>
+                <p>Vous pouvez essayer de recharger la page, ou contacter votre administrateur si l'erreur persiste.</p>
+              </div>
               <p
                 class="notification is-default"
-                v-if="pendingUserAccounts.length === 0"
+                v-else-if="pendingUserAccounts.length === 0"
               >Aucun compte en attente de validation</p>
               <div v-else>
                 <h2 class="custom-card-title">Comptes en attente de validation</h2>
@@ -57,6 +60,7 @@
   data() {
     return {
       isLoading: false,
+      hasLoadingError: false,
     }
   },
   mounted() {
@@ -91,7 +95,13 @@
     },
     async updatePendingAccount(){
       this.isLoading = true
-      await this.$store.dispatch('fetchPendingUserAccounts')
+      try {
+        await this.$store.dispatch('fetchPendingUserAccounts')
+        this.hasLoadingError = false
+      } catch (e:any) {
+        console.error('Failed to fetch pending accounts', e)
+        this.hasLoadingError = true
+      }
       this.isLoading = false
     }
   },

--- a/src/views/admin/PendingAccounts.vue
+++ b/src/views/admin/PendingAccounts.vue
@@ -3,41 +3,44 @@
     <div class="container mt-5">
       <div class="columns is-tablet">
         <div class="column">
-           <loading v-model:active="isLoading"
-                 :can-cancel="false"
-                 :is-full-page= "true"/>
-          <div
-            v-if="!isLoading" class="accounts card custom-card custom-card-padding"
-          >
-         <div v-if="pendingUserAccounts.length === 0">Aucun compte en attente de validation</div>
+          <div class="accounts card custom-card custom-card-padding">
          
-        <div v-else>
-         <h2 class="custom-card-title">Comptes en attente de validation</h2>
-          <table   class="table is-striped is-fullwidth">
-           <thead>
-                <tr>
-                  <th>Utilisateur</th>
-                  <th class="has-text-right">Valider</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="account in pendingUserAccounts" :key="account.id">
-                  <td>
-                    {{account.name}} {{ account.markBackend ? `(via ${account.backendId})` : ""}}
-                  </td>
-                  <td class="has-text-right">
-                    <a
-                      class="button is-primary custom-button custom-inverted is-small is-pulled-right"
-                      v-on:click="validateUserAccount(account)"
-                    >
-                      valider
-                    </a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-        </div>
-      </div>
+            <loading v-model:active="isLoading"
+                 :can-cancel="false"
+                 :is-full-page= "false"/>
+            <div v-if="!isLoading">
+              <p
+                class="notification is-default"
+                v-if="pendingUserAccounts.length === 0"
+              >Aucun compte en attente de validation</p>
+              <div v-else>
+                <h2 class="custom-card-title">Comptes en attente de validation</h2>
+                <table class="table is-striped is-fullwidth">
+                 <thead>
+                    <tr>
+                      <th>Utilisateur</th>
+                      <th class="has-text-right">Valider</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="account in pendingUserAccounts" :key="account.id">
+                      <td>
+                        {{account.name}} {{ account.markBackend ? `(via ${account.backendId})` : ""}}
+                      </td>
+                      <td class="has-text-right">
+                        <a
+                          class="button is-primary custom-button custom-inverted is-small is-pulled-right"
+                          v-on:click="validateUserAccount(account)"
+                        >
+                          valider
+                        </a>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/views/admin/PendingCredits.vue
+++ b/src/views/admin/PendingCredits.vue
@@ -6,40 +6,46 @@
           <div
             class="accounts card custom-card custom-card-padding"
           >
-            <h2 class="custom-card-title">Opérations de crédit en attente de validation</h2>
-            <table class="table is-striped is-fullwidth">
-              <thead>
-                <tr>
-                  <th>Utilisateur</th>
-                  <th>Montant</th>
-                  <th class="has-text-right">Valider</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="request in pendingCreditRequests">
-                  <td>
-                    {{request.relatedUser}} {{ request.markBackend ? `(on ${request.backendId})` : ""}}
-                  </td>
-                  <td>
-                    {{
-                      parseFloat(request.amount).toLocaleString(
-                        "fr", {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2
-                        })
-                    }} {{request.currency}}
-                  </td>
-                  <td class="has-text-right">
-                    <a
-                      class="button is-primary custom-button custom-inverted is-small is-pulled-right"
-                      v-on:click="validateCreditRequest(request)"
-                    >
-                      valider
-                    </a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            <p
+              class="notification is-default"
+              v-if="pendingCreditRequests.length === 0"
+            >Aucune demande de crédit en attente de validation</p>
+            <div v-else>
+              <h2 class="custom-card-title">Opérations de crédit en attente de validation</h2>
+              <table class="table is-striped is-fullwidth">
+                <thead>
+                  <tr>
+                    <th>Utilisateur</th>
+                    <th>Montant</th>
+                    <th class="has-text-right">Valider</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="request in pendingCreditRequests">
+                    <td>
+                      {{request.relatedUser}} {{ request.markBackend ? `(on ${request.backendId})` : ""}}
+                    </td>
+                    <td>
+                      {{
+                        parseFloat(request.amount).toLocaleString(
+                          "fr", {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2
+                          })
+                      }} {{request.currency}}
+                    </td>
+                    <td class="has-text-right">
+                      <a
+                        class="button is-primary custom-button custom-inverted is-small is-pulled-right"
+                        v-on:click="validateCreditRequest(request)"
+                      >
+                        valider
+                      </a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>

--- a/src/views/admin/PendingCredits.vue
+++ b/src/views/admin/PendingCredits.vue
@@ -6,9 +6,13 @@
           <div
             class="accounts card custom-card custom-card-padding"
           >
+            <div class="notification is-danger is-light" v-if="hasLoadingError">
+              <p class="mb-4">Une erreur inattendue est survenue pendant le chargement de la liste de demandes de crédits. Veuillez nous excuser pour le désagrément.</p>
+              <p>Vous pouvez essayer de recharger la page, ou contacter votre administrateur si l'erreur persiste.</p>
+            </div>
             <p
               class="notification is-default"
-              v-if="pendingCreditRequests.length === 0"
+              v-else-if="pendingCreditRequests.length === 0"
             >Aucune demande de crédit en attente de validation</p>
             <div v-else>
               <h2 class="custom-card-title">Opérations de crédit en attente de validation</h2>
@@ -58,13 +62,18 @@
 
   @Options({
     name:"PendingCredits",
+    data() {
+      return {
+        hasLoadingError: false,
+      }
+    },
     mounted() {
-      this.$store.dispatch('fetchPendingCreditRequests')
+      this.updatePendingCreditRequests()
     },
     computed: {
       pendingCreditRequests(): Array<any> {
         return this.$store.state.lokapi.pendingCreditRequests
-      }
+      },
     },
     methods: {
       async validateCreditRequest (request: any): Promise<void> {
@@ -88,6 +97,15 @@
           showConfirmButton: false,
           timer: 3000
         })
+      },
+      async updatePendingCreditRequests() {
+        try {
+          await this.$store.dispatch('fetchPendingCreditRequests')
+          this.hasLoadingError = false
+        } catch (e:any) {
+          console.error('Failed to fetch pending credit requests', e)
+          this.hasLoadingError = true
+        }
       }
     },
   })


### PR DESCRIPTION
Report error to the user with a toast if there is a network error while trying to autologin
Make all empty data lists (credits, accounts, pending accounts, transactions) homogenous and show look-alike messages.
Catch lokapi errors
Make these errors bubble up in the UI as graceful "unavailability" messages.

(closes #148)