### PR TITLE
fix: fix bug where password was not reset after logout

### DIFF
--- a/src/services/lokapiService.ts
+++ b/src/services/lokapiService.ts
@@ -11,58 +11,57 @@ export class LokAPI extends LokAPIBrowserAbstract {
     cyclos,
   }
 
+  rememberedPassword: any = { pwd: "", inputTime: 0 }
+
   constructor(host: string, db: string, localPasswordRetentionTime = 900) {
     super(host, db)
-    this.requestLocalPassword = ((state) => {
-      let rememberedPassword = { pwd: "", inputTime: 0 }
-      return async (state: any) => {
-        let text = ""
+    this.requestLocalPassword = async (state: any) => {
+      let text = ""
 
-        // Lets see if we have a (still valid) password in there...
-        // ... that was used less than 30 secs ago.
-        // If it's the case, we will provide it to the lokapi right away
-        if (
-          rememberedPassword.pwd.length > 0 &&
-          rememberedPassword.inputTime + localPasswordRetentionTime * 1000 >
-            Date.now() &&
-          state === "firstTry"
-        ) {
-          // Valid pwd -> update the last used time and provide the pwd
-          // to the lokapi
-          rememberedPassword.inputTime = Date.now()
-          return rememberedPassword.pwd
-        }
-
-        // No valid pwd, so we make sure the pwd is reset and ask for it
-        // again
-        rememberedPassword = { pwd: "", inputTime: 0 }
-
-        if (state === "failedUnlock") {
-          text =
-            "Échec du déchiffrage. " +
-            "Le mot de passe était probablement incorrect. " +
-            "Ré-essayez une nouvelle fois" // XXXvlab: need i18n
-        }
-        const ret = await Swal.fire({
-          title: "Entrez votre mot de passe", // XXXvlab: need i18n
-          text,
-          showCloseButton: true,
-          input: "password",
-          inputLabel: "Mot de passe du portefeuille", // XXXvlab: need i18n
-          inputPlaceholder: "Votre mot de passe", // XXXvlab: need i18n
-          inputAttributes: {
-            maxlength: "32",
-            autocapitalize: "off",
-            autocorrect: "off",
-          },
-        })
-        if (ret.isConfirmed) {
-          rememberedPassword = { pwd: ret.value, inputTime: Date.now() }
-          return ret.value
-        }
-        throw new Error("User canceled the dialog box")
+      // Lets see if we have a (still valid) password in there...
+      // ... that was used less than 30 secs ago.
+      // If it's the case, we will provide it to the lokapi right away
+      if (
+        this.rememberedPassword.pwd.length > 0 &&
+        this.rememberedPassword.inputTime + localPasswordRetentionTime * 1000 >
+          Date.now() &&
+        state === "firstTry"
+      ) {
+        // Valid pwd -> update the last used time and provide the pwd
+        // to the lokapi
+        this.rememberedPassword.inputTime = Date.now()
+        return this.rememberedPassword.pwd
       }
-    })()
+
+      // No valid pwd, so we make sure the pwd is reset and ask for it
+      // again
+      this.rememberedPassword = { pwd: "", inputTime: 0 }
+
+      if (state === "failedUnlock") {
+        text =
+          "Échec du déchiffrage. " +
+          "Le mot de passe était probablement incorrect. " +
+          "Ré-essayez une nouvelle fois" // XXXvlab: need i18n
+      }
+      const ret = await Swal.fire({
+        title: "Entrez votre mot de passe", // XXXvlab: need i18n
+        text,
+        showCloseButton: true,
+        input: "password",
+        inputLabel: "Mot de passe du portefeuille", // XXXvlab: need i18n
+        inputPlaceholder: "Votre mot de passe", // XXXvlab: need i18n
+        inputAttributes: {
+          maxlength: "32",
+          autocapitalize: "off",
+          autocorrect: "off",
+        },
+      })
+      if (ret.isConfirmed) {
+        this.rememberedPassword = { pwd: ret.value, inputTime: Date.now() }
+        return ret.value
+      }
+      throw new Error("User canceled the dialog box")
+    }
   }
 
   requestLogin() {
@@ -71,6 +70,14 @@ export class LokAPI extends LokAPIBrowserAbstract {
       console.log("Login requested !")
       router.push("/")
     }
+  }
+
+  /**
+   * Ensure we reset the stored wallet password whenever we log out of the app
+   */
+  logout() {
+    this.rememberedPassword = { pwd: "", inputTime: 0 }
+    return super.logout()
   }
 
   /**


### PR DESCRIPTION
Fix bug where password was not reset after logout which caused a password prompt wrongly stating that the password was
entered with an error. The error was on the wallet remembered password and happened upon validating a transaction, ogging out, logging in, and immediately try to perform a money transaction with this second account.

(Closes #188)