### PR TITLE
Fix user disconnected from Monujo when he uses other apps and comes back

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,8 @@
           }
           console.log("Error while trying to autolog", e)
         }
+        if (this.$store.getters.isAuthenticated && this.$route.name === "Login")
+          this.$router.push({ name: "dashboard" })
       }
     },
     computed: {


### PR DESCRIPTION
fixes #252

Will prevent "Monujo account disconnection when switching between
several apps", where the user was not really disconnected, but only
navigated to the login (aka root) page automatically when focusing back
on the Monujo app after using some other app. This code will ensure the
user will access the login page only if he is really disconnected,
otherwise he will be redirected to his dashboard.