### PR TITLE
fix: prevent having to double click on recipient in search modal

### DIFF
--- a/src/components/MoneyTransferModal.vue
+++ b/src/components/MoneyTransferModal.vue
@@ -85,7 +85,7 @@
                 <RecipientItem
                   :recipient="recipient"
                   :key="index"
-                  @select="handleClickRecipient(recipient)"
+                  @mousedown.prevent="handleClickRecipient(recipient)"
                 />
               </div>
             </template>


### PR DESCRIPTION
On android mobile, there was some cases where selecting the recipient would trigger the search again and forces the user to click again to select a recipient.